### PR TITLE
Include land boundaries in psi output

### DIFF
--- a/veros/core/streamfunction/streamfunction_init.py
+++ b/veros/core/streamfunction/streamfunction_init.py
@@ -97,7 +97,7 @@ def streamfunction_init(vs):
     forc = allocate(vs, ('xu', 'yu'))
 
     # initialize with random noise to achieve uniform convergence
-    vs.psin[...] = vs.maskZ[..., -1, np.newaxis]# np.random.rand(*vs.psin.shape) * vs.maskZ[..., -1, np.newaxis]
+    vs.psin[...] = vs.maskZ[..., -1, np.newaxis]
 
     for isle in range(vs.nisle):
         logger.info(' Solving for boundary contribution by island {:d}'.format(isle))

--- a/veros/diagnostics/io_tools/netcdf.py
+++ b/veros/diagnostics/io_tools/netcdf.py
@@ -91,7 +91,7 @@ def advance_time(vs, time_step, time_value, ncfile):
 def write_variable(vs, key, var, var_data, ncfile, time_step=None):
     var_data = var_data * var.scale
 
-    gridmask = variables.get_grid_mask(vs, var.dims)
+    gridmask = var.get_mask(vs)
     if gridmask is not None:
         newaxes = (slice(None),) * gridmask.ndim + (np.newaxis,) * (var_data.ndim - gridmask.ndim)
         var_data = np.where(gridmask.astype(np.bool)[newaxes], var_data, variables.FILL_VALUE)

--- a/veros/variables.py
+++ b/veros/variables.py
@@ -74,6 +74,8 @@ DEFAULT_MASKS = {
     ZETA_GRID: lambda vs: vs.maskZ
 }
 
+ZETA_HOR_ERODED = lambda vs: vs.maskZ[:, :, -1] | vs.boundary_mask.sum(axis=2)  # noqa: E731
+
 
 def get_dimensions(vs, grid, include_ghosts=True, local=True):
     px, py = runtime_settings.num_proc
@@ -409,8 +411,7 @@ MAIN_VARIABLES = OrderedDict([
 
     ('psi', Variable(
         'Streamfunction', ZETA_HOR + TIMESTEPS, 'm^3/s', 'Barotropic streamfunction',
-        output=True, write_to_restart=True,
-        mask=lambda vs: vs.maskZ[:, :, -1] | vs.boundary_mask.sum(axis=2)
+        output=True, write_to_restart=True, mask=ZETA_HOR_ERODED
     )),
     ('dpsi', Variable(
         'Streamfunction tendency', ZETA_HOR + TIMESTEPS, 'm^3/s^2',
@@ -425,7 +426,7 @@ MAIN_VARIABLES = OrderedDict([
     ('psin', Variable(
         'Boundary streamfunction', ZETA_HOR + ISLE, 'm^3/s',
         'Boundary streamfunction', output=True, time_dependent=False,
-        mask=lambda vs: vs.maskZ[:, :, -1] | vs.boundary_mask.sum(axis=2)
+        mask=ZETA_HOR_ERODED
     )),
     ('dpsin', Variable(
         'Boundary streamfunction factor', ISLE + TIMESTEPS, '?',


### PR DESCRIPTION
- Variables now support custom nodata masks
- Include land boundaries for psi and psin so users can estimate transports through passages