### PR TITLE
FIX: kappaM_0 and kappaH_0 are settings

### DIFF
--- a/veros/core/tke.py
+++ b/veros/core/tke.py
@@ -13,8 +13,8 @@ def set_tke_diffusivities(state):
         tke_diff_out = set_tke_diffusivities_kernel(state)
         vs.update(tke_diff_out)
     else:
-        vs.kappaM = update(vs.kappaM, at[...], vs.kappaM_0)
-        vs.kappaH = update(vs.kappaH, at[...], vs.kappaH_0)
+        vs.kappaM = update(vs.kappaM, at[...], settings.kappaM_0)
+        vs.kappaH = update(vs.kappaH, at[...], settings.kappaH_0)
 
 
 @veros_kernel


### PR DESCRIPTION
I tured tke off, and got that `vs.kappaH/M_0` do not exist - changing to settings seems to work.

This is only tested locally, but would benefit from being added to your test suite.  