### PR TITLE
Do not import plugins when finding setup files

### DIFF
--- a/veros/__init__.py
+++ b/veros/__init__.py
@@ -89,13 +89,6 @@ class _PublicAPI(types.ModuleType):
 
         return VerosState
 
-    @property
-    @_reraise_exceptions
-    def VerosLegacy(self):
-        from veros.veros_legacy import VerosLegacy
-
-        return VerosLegacy
-
 
 sys.modules[__name__].__class__ = _PublicAPI
 

--- a/veros/cli/veros_copy_setup.py
+++ b/veros/cli/veros_copy_setup.py
@@ -17,8 +17,14 @@ SETUPS = {}
 
 setup_dirs = []
 
+
 for e in entrypoints.get_group_all("veros.setup_dirs"):
-    modpath = os.path.dirname(importlib.util.find_spec(e.module_name).origin)
+    # - hack to prevent actually importing plugins -
+    # we can only find the location of top-level modules
+    # so assume that foo.bar.baz always resolves to foo/bar/baz
+    base_module, *submodules = e.module_name.split(".")
+
+    modpath = os.path.join(os.path.dirname(importlib.util.find_spec(base_module).origin), *submodules)
     setup_dirs.append(modpath)
 
 for setup_dir in os.environ.get(SETUPDIR_ENVVAR, "").split(";"):


### PR DESCRIPTION
This sacrifices some flexibility, but makes it that malformed plugins cannot prevent Veros from running anymore just because they are installed.